### PR TITLE
deactivate plugins on api call

### DIFF
--- a/classes/Editor/class.xonoEditorGUI.php
+++ b/classes/Editor/class.xonoEditorGUI.php
@@ -169,7 +169,7 @@ class xonoEditorGUI extends xonoAbstractGUI
         $editor['mode'] = $this->determineAccessRights($withinPotentialTimeLimit);
         $editor['lang'] = $this->dic->user()->getLanguage();
         $editor['customization']= array(
-            "plugin" => false,
+            "plugins" => false,
             "forcesave" => true);
         $as_array['editorConfig'] = $editor;
 

--- a/classes/Editor/class.xonoEditorGUI.php
+++ b/classes/Editor/class.xonoEditorGUI.php
@@ -168,7 +168,9 @@ class xonoEditorGUI extends xonoAbstractGUI
         $editor['user'] = $this->buildUserArray($this->dic->user()->getId());
         $editor['mode'] = $this->determineAccessRights($withinPotentialTimeLimit);
         $editor['lang'] = $this->dic->user()->getLanguage();
-        $editor['customization']= array("forcesave" => true);
+        $editor['customization']= array(
+            "plugin" => false,
+            "forcesave" => true);
         $as_array['editorConfig'] = $editor;
 
         // events config


### PR DESCRIPTION
This PR disables the plugins tab via the api call. As a feature we should one day implement this as a config option.